### PR TITLE
Features/vertex array caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ Thumbs.db
 /ios-moe/xcode/native/
 *.jar
 *.zip
+*.gif

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -253,8 +253,10 @@ public abstract class AbstractShapeDrawer {
         return cacheDraws;
     }
 
-    public void startCaching() {
+    public boolean startCaching() {
+        boolean wasCaching = isCachingDraws();
         this.cacheDraws = true;
+        return wasCaching;
     }
 
     public void endCaching() {

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -2,6 +2,7 @@ package space.earlygrey.shapedrawer;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -229,8 +230,8 @@ public abstract class AbstractShapeDrawer {
     }
 
     /**
-     * Sets the colour of the ShapeDrawer. This works just like {@link Batch#setColor(Color)} though drawing is not affected by
-     * the colour of the Batch.
+     * <p>Sets the colour of the ShapeDrawer. This works just like {@link Batch#setColor(Color)} though drawing is not affected by
+     * the colour of the Batch.</p>
      * @param floatBits the packed float value of the colour, see {@link Color#toFloatBits()}.
      * @return the previous packed float value of the ShapeDrawer's colour
      */
@@ -248,17 +249,28 @@ public abstract class AbstractShapeDrawer {
         return floatBits;
     }
 
-
+    /**
+     *
+     * @return whether drawing is currently being cached
+     */
     protected boolean isCachingDraws() {
         return cacheDraws;
     }
 
+    /**
+     * <p>Begin caching draw calls by storing vertex information in a float[] until it all gets set to the
+     * Batch with one call to {@link Batch#draw(Texture, float[], int, int)}.</p>
+     * @return whether drawing was being cached before this method was called
+     */
     protected boolean startCaching() {
         boolean wasCaching = isCachingDraws();
         this.cacheDraws = true;
         return wasCaching;
     }
 
+    /**
+     * <p>Stops caching and calls {@link Batch#draw(Texture, float[], int, int)} if anything is cached.</p>
+     */
     protected void endCaching() {
         this.cacheDraws = false;
         if (vertexCount>0) drawVerts();
@@ -269,6 +281,10 @@ public abstract class AbstractShapeDrawer {
     // DRAWING METHODS
     //================================================================================
 
+    /**
+     * <p>Adds the colour and texture coordinates to the cache and progresses the index. If drawing is
+     * not currently being cached, immediately calls {@link #drawVerts()}.</p>
+     */
     protected void pushVerts() {
         int i = getArrayOffset();
         verts[i + SpriteBatch.U1] = r.getU();
@@ -289,15 +305,24 @@ public abstract class AbstractShapeDrawer {
         }
     }
 
+    /**
+     * @return whether the cache can currently hold another set of vertex information of size {@link #PUSH_SIZE}.
+     */
     protected boolean isCacheFull() {
         return verts.length - PUSH_SIZE < PUSH_SIZE * vertexCount;
     }
 
+    /**
+     * <p>Calls {@link Batch#draw(Texture, float[], int, int)} using the currently cached vertex information.</p>
+     */
     protected void drawVerts() {
         if (vertexCount == 0) return;
         batch.draw(r.getTexture(), verts, 0, getArrayOffset());
-        //System.out.println(vertexCount);
         vertexCount = 0;
+    }
+
+    protected int getArrayOffset() {
+        return VERTEX_SIZE * vertexCount;
     }
 
     protected void x1(float x1){verts[getArrayOffset() + SpriteBatch.X1] = x1;}
@@ -316,9 +341,5 @@ public abstract class AbstractShapeDrawer {
     protected float y3() {return verts[getArrayOffset() + SpriteBatch.Y3];}
     protected float x4() {return verts[getArrayOffset() + SpriteBatch.X4];}
     protected float y4() {return verts[getArrayOffset() + SpriteBatch.Y4];}
-
-    protected int getArrayOffset() {
-        return VERTEX_SIZE * vertexCount;
-    }
 
 }

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -22,7 +22,7 @@ public abstract class AbstractShapeDrawer {
     protected final Batch batch;
     protected TextureRegion r;
     protected float floatBits;
-    protected final float[] verts = new float[4000];
+    protected final float[] verts = new float[2000];
     protected int vertexCount;
 
     protected float pixelSize = 1, halfPixelSize = 0.5f * pixelSize;
@@ -249,17 +249,17 @@ public abstract class AbstractShapeDrawer {
     }
 
 
-    public boolean isCachingDraws() {
+    protected boolean isCachingDraws() {
         return cacheDraws;
     }
 
-    public boolean startCaching() {
+    protected boolean startCaching() {
         boolean wasCaching = isCachingDraws();
         this.cacheDraws = true;
         return wasCaching;
     }
 
-    public void endCaching() {
+    protected void endCaching() {
         this.cacheDraws = false;
         if (vertexCount>0) drawVerts();
     }

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -5,9 +5,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Matrix4;
-import com.badlogic.gdx.math.Vector2;
 
 /**
  * <p>Contains the mechanics for using the Batch and settings such as line width and pixel size.</p>
@@ -23,14 +21,22 @@ public abstract class AbstractShapeDrawer {
 
     protected final Batch batch;
     protected TextureRegion r;
-    protected final float[] verts = new float[20];
+    protected float floatBits;
+    protected final float[] verts = new float[4000];
+    protected int vertexCount;
 
     protected float pixelSize = 1, halfPixelSize = 0.5f * pixelSize;
     protected float offset = ShapeUtils.EPSILON * pixelSize;
     protected float defaultLineWidth = pixelSize;
     protected boolean defaultSnap = false;
+    protected boolean cacheDraws = false;
 
     protected static final Matrix4 mat4 = new Matrix4();
+
+    protected static final int VERTEX_SIZE = 5;
+    protected static final int VERTICES_PER_PUSH = 4;
+    protected static final int PUSH_SIZE = VERTICES_PER_PUSH * VERTEX_SIZE;
+
 
 
     //================================================================================
@@ -205,14 +211,6 @@ public abstract class AbstractShapeDrawer {
     public TextureRegion setTextureRegion(TextureRegion region) {
         TextureRegion oldRegion = this.r;
         this.r = region;
-        verts[SpriteBatch.U1] = r.getU();
-        verts[SpriteBatch.V1] = r.getV();
-        verts[SpriteBatch.U2] = r.getU2();
-        verts[SpriteBatch.V2] = r.getV();
-        verts[SpriteBatch.U3] = r.getU2();
-        verts[SpriteBatch.V3] = r.getV2();
-        verts[SpriteBatch.U4] = r.getU();
-        verts[SpriteBatch.V4] = r.getV2();
         return oldRegion;
     }
 
@@ -234,10 +232,7 @@ public abstract class AbstractShapeDrawer {
      */
     public float setColor(float floatBits) {
         float oldColor = getPackedColor();
-        verts[SpriteBatch.C1] = floatBits;
-        verts[SpriteBatch.C2] = floatBits;
-        verts[SpriteBatch.C3] = floatBits;
-        verts[SpriteBatch.C4] = floatBits;
+        this.floatBits = floatBits;
         return oldColor;
     }
 
@@ -246,45 +241,72 @@ public abstract class AbstractShapeDrawer {
      * @return the packed colour of this ShapeDrawer
      */
     public float getPackedColor() {
-        return verts[SpriteBatch.C1];
+        return floatBits;
     }
 
 
     //================================================================================
-    // BATCH UTILITY METHODS
+    // DRAWING METHODS
     //================================================================================
+
+    public boolean isCachingDraws() {
+        return cacheDraws;
+    }
+
+    public void startCaching() {
+        this.cacheDraws = true;
+    }
+
+    public void endCaching() {
+        this.cacheDraws = false;
+        if (vertexCount>0) drawVerts();
+    }
+
+    protected void pushVerts() {
+        verts[getArrayOffset() + SpriteBatch.U1] = r.getU();
+        verts[getArrayOffset() + SpriteBatch.V1] = r.getV();
+        verts[getArrayOffset() + SpriteBatch.U2] = r.getU2();
+        verts[getArrayOffset() + SpriteBatch.V2] = r.getV();
+        verts[getArrayOffset() + SpriteBatch.U3] = r.getU2();
+        verts[getArrayOffset() + SpriteBatch.V3] = r.getV2();
+        verts[getArrayOffset() + SpriteBatch.U4] = r.getU();
+        verts[getArrayOffset() + SpriteBatch.V4] = r.getV2();
+        verts[getArrayOffset() + SpriteBatch.C1] = floatBits;
+        verts[getArrayOffset() + SpriteBatch.C2] = floatBits;
+        verts[getArrayOffset() + SpriteBatch.C3] = floatBits;
+        verts[getArrayOffset() + SpriteBatch.C4] = floatBits;
+        vertexCount += VERTICES_PER_PUSH;
+        if (!isCachingDraws() || verts.length - PUSH_SIZE < PUSH_SIZE * vertexCount) {
+            drawVerts();
+        }
+    }
 
     protected void drawVerts() {
-        batch.draw(r.getTexture(), verts, 0, 20);
+        if (vertexCount == 0) return;
+        batch.draw(r.getTexture(), verts, 0, getArrayOffset());
+        //System.out.println(vertexCount);
+        vertexCount = 0;
     }
 
-    protected void x1(float x1){verts[SpriteBatch.X1] = x1;}
-    protected void y1(float y1){verts[SpriteBatch.Y1] = y1;}
-    protected void x2(float x2){verts[SpriteBatch.X2] = x2;}
-    protected void y2(float y2){verts[SpriteBatch.Y2] = y2;}
-    protected void x3(float x3){verts[SpriteBatch.X3] = x3;}
-    protected void y3(float y3){verts[SpriteBatch.Y3] = y3;}
-    protected void x4(float x4){verts[SpriteBatch.X4] = x4;}
-    protected void y4(float y4){verts[SpriteBatch.Y4] = y4;}
-    protected void vert1(float x, float y) {x1(x);y1(y);}
-    protected void vert2(float x, float y) {x2(x);y2(y);}
-    protected void vert3(float x, float y) {x3(x);y3(y);}
-    protected void vert4(float x, float y) {x4(x);y4(y);}
-    protected void vert1(Vector2 V) {vert1(V.x, V.y);}
-    protected void vert2(Vector2 V) {vert2(V.x, V.y);}
-    protected void vert3(Vector2 V) {vert3(V.x, V.y);}
-    protected void vert4(Vector2 V) {vert4(V.x, V.y);}
-    protected void vert1(Vector2 V, Vector2 offset) {vert1(V.x+offset.x, V.y+offset.y);}
-    protected void vert2(Vector2 V, Vector2 offset) {vert2(V.x+offset.x, V.y+offset.y);}
-    protected void vert3(Vector2 V, Vector2 offset) {vert3(V.x+offset.x, V.y+offset.y);}
-    protected void vert4(Vector2 V, Vector2 offset) {vert4(V.x+offset.x, V.y+offset.y);}
-    protected float x1() {return verts[SpriteBatch.X1];}
-    protected float y1() {return verts[SpriteBatch.Y1];}
-    protected float x2() {return verts[SpriteBatch.X2];}
-    protected float y2() {return verts[SpriteBatch.Y2];}
-    protected float x3() {return verts[SpriteBatch.X3];}
-    protected float y3() {return verts[SpriteBatch.Y3];}
-    protected float x4() {return verts[SpriteBatch.X4];}
-    protected float y4() {return verts[SpriteBatch.Y4];}
+    protected void x1(float x1){verts[getArrayOffset() + SpriteBatch.X1] = x1;}
+    protected void y1(float y1){verts[getArrayOffset() + SpriteBatch.Y1] = y1;}
+    protected void x2(float x2){verts[getArrayOffset() + SpriteBatch.X2] = x2;}
+    protected void y2(float y2){verts[getArrayOffset() + SpriteBatch.Y2] = y2;}
+    protected void x3(float x3){verts[getArrayOffset() + SpriteBatch.X3] = x3;}
+    protected void y3(float y3){verts[getArrayOffset() + SpriteBatch.Y3] = y3;}
+    protected void x4(float x4){verts[getArrayOffset() + SpriteBatch.X4] = x4;}
+    protected void y4(float y4){verts[getArrayOffset() + SpriteBatch.Y4] = y4;}
+    protected float x1() {return verts[getArrayOffset() + SpriteBatch.X1];}
+    protected float y1() {return verts[getArrayOffset() + SpriteBatch.Y1];}
+    protected float x2() {return verts[getArrayOffset() + SpriteBatch.X2];}
+    protected float y2() {return verts[getArrayOffset() + SpriteBatch.Y2];}
+    protected float x3() {return verts[getArrayOffset() + SpriteBatch.X3];}
+    protected float y3() {return verts[getArrayOffset() + SpriteBatch.Y3];}
+    protected float x4() {return verts[getArrayOffset() + SpriteBatch.X4];}
+    protected float y4() {return verts[getArrayOffset() + SpriteBatch.Y4];}
+
+    protected int getArrayOffset() {
+        return VERTEX_SIZE * vertexCount;
+    }
 
 }

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -33,10 +33,7 @@ public abstract class AbstractShapeDrawer {
 
     protected static final Matrix4 mat4 = new Matrix4();
 
-    protected static final int VERTEX_SIZE = 5;
-    protected static final int VERTICES_PER_PUSH = 4;
-    protected static final int PUSH_SIZE = VERTICES_PER_PUSH * VERTEX_SIZE;
-
+    protected final int VERTEX_SIZE, VERTICES_PER_PUSH, PUSH_SIZE;
 
 
     //================================================================================
@@ -49,9 +46,16 @@ public abstract class AbstractShapeDrawer {
      * @param region the texture region used for drawing. Can be changed later.
      */
     protected AbstractShapeDrawer(Batch batch, TextureRegion region) {
+        this(batch, region, 5, 4);
+    }
+
+    protected AbstractShapeDrawer(Batch batch, TextureRegion region, int vertexSize, int verticesPerPush) {
         this.batch = batch;
         setTextureRegion(region);
         setColor(Color.WHITE);
+        VERTEX_SIZE = vertexSize;
+        VERTICES_PER_PUSH = verticesPerPush;
+        PUSH_SIZE = VERTICES_PER_PUSH * VERTEX_SIZE;
     }
 
 
@@ -245,10 +249,6 @@ public abstract class AbstractShapeDrawer {
     }
 
 
-    //================================================================================
-    // DRAWING METHODS
-    //================================================================================
-
     public boolean isCachingDraws() {
         return cacheDraws;
     }
@@ -262,23 +262,33 @@ public abstract class AbstractShapeDrawer {
         if (vertexCount>0) drawVerts();
     }
 
+
+    //================================================================================
+    // DRAWING METHODS
+    //================================================================================
+
     protected void pushVerts() {
-        verts[getArrayOffset() + SpriteBatch.U1] = r.getU();
-        verts[getArrayOffset() + SpriteBatch.V1] = r.getV();
-        verts[getArrayOffset() + SpriteBatch.U2] = r.getU2();
-        verts[getArrayOffset() + SpriteBatch.V2] = r.getV();
-        verts[getArrayOffset() + SpriteBatch.U3] = r.getU2();
-        verts[getArrayOffset() + SpriteBatch.V3] = r.getV2();
-        verts[getArrayOffset() + SpriteBatch.U4] = r.getU();
-        verts[getArrayOffset() + SpriteBatch.V4] = r.getV2();
-        verts[getArrayOffset() + SpriteBatch.C1] = floatBits;
-        verts[getArrayOffset() + SpriteBatch.C2] = floatBits;
-        verts[getArrayOffset() + SpriteBatch.C3] = floatBits;
-        verts[getArrayOffset() + SpriteBatch.C4] = floatBits;
+        int i = getArrayOffset();
+        verts[i + SpriteBatch.U1] = r.getU();
+        verts[i + SpriteBatch.V1] = r.getV();
+        verts[i + SpriteBatch.U2] = r.getU2();
+        verts[i + SpriteBatch.V2] = r.getV();
+        verts[i + SpriteBatch.U3] = r.getU2();
+        verts[i + SpriteBatch.V3] = r.getV2();
+        verts[i + SpriteBatch.U4] = r.getU();
+        verts[i + SpriteBatch.V4] = r.getV2();
+        verts[i + SpriteBatch.C1] = floatBits;
+        verts[i + SpriteBatch.C2] = floatBits;
+        verts[i + SpriteBatch.C3] = floatBits;
+        verts[i + SpriteBatch.C4] = floatBits;
         vertexCount += VERTICES_PER_PUSH;
-        if (!isCachingDraws() || verts.length - PUSH_SIZE < PUSH_SIZE * vertexCount) {
+        if (!isCachingDraws() || isCacheFull()) {
             drawVerts();
         }
+    }
+
+    protected boolean isCacheFull() {
+        return verts.length - PUSH_SIZE < PUSH_SIZE * vertexCount;
     }
 
     protected void drawVerts() {

--- a/drawer/src/space/earlygrey/shapedrawer/DrawerTemplate.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DrawerTemplate.java
@@ -23,6 +23,7 @@ abstract class DrawerTemplate {
         vert4(x3(), y3());
         drawer.pushVerts();
     }
+
     void drawSmoothJoinFill(Vector2 A, Vector2 B, Vector2 C, Vector2 D, Vector2 E, Vector2 offset, float cos, float sin, float halfLineWidth) {
         boolean bendsLeft = Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, false);
         Vector2 V1 = bendsLeft?E:D, V2 = bendsLeft?D:E;
@@ -81,17 +82,31 @@ abstract class DrawerTemplate {
     void printABC() {
         System.out.println("A: "+A+", B: "+B+", C: "+C);
     }
+
+    void drawPoint(Vector2 point, Color color) {
+        drawPoint(point.x, point.y, color);
+    }
+    void drawPoint(Vector2 point, Color color, float r) {
+        drawPoint(point, color.toFloatBits(), r);
+    }
+    void drawPoint(Vector2 point, float color, float r) {
+        drawPoint(point.x, point.y, color, r);
+    }
+    void drawPoint(float x, float y, Color color) {
+        drawPoint(x, y, color.toFloatBits(), 3);
+    }
+    void drawPoint(float x, float y, float color, float r) {
+        Color c = drawer.getBatch().getColor();
+        drawer.getBatch().setPackedColor(color);
+        drawer.getBatch().draw(drawer.getRegion(), x-r, y-r, 2*r, 2*r);
+        drawer.getBatch().setColor(c);
+    }
+
     void draw1234() {
-        float s = 3, c = drawer.getPackedColor();
-        drawer.getBatch().setColor(Color.GREEN);
-        drawer.getBatch().draw(drawer.getRegion(), x1()-s, y1()-s, 2*s, 2*s);
-        drawer.getBatch().setColor(Color.ORANGE);
-        drawer.getBatch().draw(drawer.getRegion(), x2()-s, y2()-s, 2*s, 2*s);
-        drawer.getBatch().setColor(Color.YELLOW);
-        drawer.getBatch().draw(drawer.getRegion(), x3()-s, y3()-s, 2*s, 2*s);
-        drawer.getBatch().setColor(Color.PURPLE);
-        drawer.getBatch().draw(drawer.getRegion(), x4()-s, y4()-s, 2*s, 2*s);
-        drawer.setColor(c);
+        drawPoint(x1(), y1(), Color.GREEN);
+        drawPoint(x2(), y2(), Color.ORANGE);
+        drawPoint(x3(), y3(), Color.YELLOW);
+        drawPoint(x4(), y4(), Color.PURPLE);
     }
 
     void drawABC() {
@@ -99,24 +114,14 @@ abstract class DrawerTemplate {
     }
 
     void drawABC(Vector2 offset) {
-        float s1 = 4, s2 = 3, s3 = 2, c = drawer.getPackedColor();
-        drawer.getBatch().setColor(Color.GREEN);
-        drawer.getBatch().draw(drawer.getRegion(), A.x-s1+offset.x, A.y-s1+offset.y, 2*s1, 2*s1);
-        drawer.getBatch().setColor(Color.ORANGE);
-        drawer.getBatch().draw(drawer.getRegion(), B.x-s2+offset.x, B.y-s2+offset.y, 2*s2, 2*s2);
-        drawer.getBatch().setColor(Color.YELLOW);
-        drawer.getBatch().draw(drawer.getRegion(), C.x-s3+offset.x, C.y-s3+offset.y, 2*s3, 2*s3);
-        drawer.setColor(c);
+        drawPoint(A, Color.GREEN);
+        drawPoint(B, Color.ORANGE);
+        drawPoint(C, Color.YELLOW);
+
     }
-
-
     void drawDE(boolean scheme1) {
-        float s = 2, c = drawer.getPackedColor();
-        drawer.getBatch().setColor(scheme1?Color.YELLOW:Color.CHARTREUSE);
-        drawer.getBatch().draw(drawer.getRegion(), D.x-s, D.y-s, 2*s, 2*s);
-        drawer.getBatch().setColor(scheme1?Color.PINK:Color.TAN);
-        drawer.getBatch().draw(drawer.getRegion(), E.x-s, E.y-s, 2*s, 2*s);
-        drawer.setColor(c);
+        drawPoint(D, scheme1?Color.YELLOW:Color.CHARTREUSE);
+        drawPoint(E, scheme1?Color.PINK:Color.TAN);
     }
     void drawDE() {
         drawDE(true);

--- a/drawer/src/space/earlygrey/shapedrawer/DrawerTemplate.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DrawerTemplate.java
@@ -14,10 +14,6 @@ abstract class DrawerTemplate {
         this.drawer = drawer;
     }
 
-    void drawVerts() {
-        drawer.drawVerts();
-    }
-
     void drawSmoothJoinFill(Vector2 A, Vector2 B, Vector2 C, Vector2 D, Vector2 E, float halfLineWidth) {
         boolean bendsLeft = Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, false);
         vert1(bendsLeft?E:D);
@@ -25,7 +21,7 @@ abstract class DrawerTemplate {
         bendsLeft = Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, true);
         vert3(bendsLeft?E:D);
         vert4(x3(), y3());
-        drawVerts();
+        drawer.pushVerts();
     }
     void drawSmoothJoinFill(Vector2 A, Vector2 B, Vector2 C, Vector2 D, Vector2 E, Vector2 offset, float cos, float sin, float halfLineWidth) {
         boolean bendsLeft = Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, false);
@@ -37,7 +33,7 @@ abstract class DrawerTemplate {
         float x = V3.x*cos-V3.y*sin  + offset.x, y = V3.x*sin+V3.y*cos + offset.y;
         vert3(x, y);
         vert4(x, y);
-        drawVerts();
+        drawer.pushVerts();
     }
 
 
@@ -81,6 +77,9 @@ abstract class DrawerTemplate {
                 "("+x3()+","+y3()+")  " +
                 "("+x4()+","+y4()+")");
 
+    }
+    void printABC() {
+        System.out.println("A: "+A+", B: "+B+", C: "+C);
     }
     void draw1234() {
         float s = 3, c = drawer.getPackedColor();

--- a/drawer/src/space/earlygrey/shapedrawer/LineDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/LineDrawer.java
@@ -7,6 +7,11 @@ class LineDrawer extends DrawerTemplate {
     }
 
     void line(float x1, float y1, float x2, float y2, float lineWidth, boolean snap) {
+        pushLine(x1, y1, x2, y2, lineWidth, snap);
+        drawer.drawVerts();
+    }
+
+    void pushLine(float x1, float y1, float x2, float y2, float lineWidth, boolean snap) {
 
         // dif=(xdif,ydif) is the vector going from (x1, y1) to the first vertex going clockwise around the border of the line.
         // l=(lx,ly) is the vector from (x1, y1) to (x2, y2)
@@ -50,7 +55,9 @@ class LineDrawer extends DrawerTemplate {
         y3(y2+ydif);
         x4(x2+xdif);
         y4(y2-ydif);
-        drawVerts();
+
+        drawer.pushVerts();
+        if (!drawer.isCachingDraws()) drawer.drawVerts();
     }
 
 

--- a/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
@@ -1,5 +1,6 @@
 package space.earlygrey.shapedrawer;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
@@ -149,12 +150,15 @@ class PathDrawer extends DrawerTemplate {
                 //draw last link on path
                 A.set(path[0], path[1]);
                 Joiner.preparePointyJoin(B, C, A, D, E, halfLineWidth);
-                vert1(E);
-                vert2(D);
+                vert3(D);
+                vert4(E);
                 drawer.pushVerts();
+
                 //draw connection back to first vertex
-                vert3(D0);
-                vert4(E0);
+                vert1(D);
+                vert2(E);
+                vert3(E0);
+                vert4(D0);
                 drawer.pushVerts();
             } else {
                 //draw last link on path

--- a/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
@@ -67,13 +67,13 @@ class PathDrawer extends DrawerTemplate {
             path.clear();
             return;
         }
-        drawer.startCaching();
+        boolean wasCaching = drawer.startCaching();
         if (joinType==JoinType.NONE) {
             drawPathNoJoin(path.items, path.size, lineWidth, open);
         } else {
             drawPathWithJoin(path.items, path.size, lineWidth, open,joinType==JoinType.POINTY);
         }
-        drawer.endCaching();
+        if (!wasCaching) drawer.endCaching();
         path.clear();
     }
 

--- a/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
@@ -111,7 +111,7 @@ class PathDrawer extends DrawerTemplate {
                     if (pointyJoin) {
                         Joiner.preparePointyJoin(vec1, A, B, D0, E0, halfLineWidth);
                     } else {
-                        Joiner.prepareSmoothJoin(vec1, A, B, D0, E0, halfLineWidth, false);
+                        Joiner.prepareSmoothJoin(vec1, A, B, D0, E0, halfLineWidth, true);
                     }
                     vert1(E0);
                     vert2(D0);
@@ -162,20 +162,21 @@ class PathDrawer extends DrawerTemplate {
                 B.set(C);
                 C.set(path[0], path[1]);
                 Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, false);
-                vert3(E);
-                vert4(D);
+                vert3(D);
+                vert4(E);
                 drawer.pushVerts();
                 drawSmoothJoinFill(A, B, C, D, E, halfLineWidth);
+
                 //draw connection back to first vertex
                 Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, true);
                 vert3(E);
                 vert4(D);
-                vert1(D0);
-                vert2(E0);
-                drawer.pushVerts();
                 A.set(path[2], path[3]);
-                drawSmoothJoinFill(B, C, A, D0, E0, halfLineWidth);
-
+                Joiner.prepareSmoothJoin(B, C, A, D, E, halfLineWidth, false);
+                vert1(D);
+                vert2(E);
+                drawer.pushVerts();
+                drawSmoothJoinFill(B, C, A, D, E, halfLineWidth);
             }
         }
     }

--- a/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PathDrawer.java
@@ -29,6 +29,10 @@ class PathDrawer extends DrawerTemplate {
         tempPath.clear();
     }
 
+    void path (FloatArray userPath, float lineWidth, JoinType joinType, boolean open) {
+        path (userPath.items, 0, userPath.size, lineWidth, joinType, open);
+    }
+
     void path (float[] userPath, float lineWidth, JoinType joinType) {
         path (userPath, 0, userPath.length, lineWidth, joinType);
     }
@@ -62,7 +66,7 @@ class PathDrawer extends DrawerTemplate {
             path.clear();
             return;
         }
-
+        drawer.startCaching();
         switch(joinType) {
             case NONE:
                 drawPathNoJoin(path.items, path.size, lineWidth, open);
@@ -74,6 +78,7 @@ class PathDrawer extends DrawerTemplate {
                 drawPathPointyJoin(path.items, path.size, lineWidth, open);
                 break;
         }
+        drawer.endCaching();
         path.clear();
     }
 
@@ -108,7 +113,7 @@ class PathDrawer extends DrawerTemplate {
                     vert2(D0);
                 }
             }
-            drawVerts();
+            drawer.pushVerts();
             vert1(x4(), y4());
             vert2(x3(), y3());
         }
@@ -117,18 +122,18 @@ class PathDrawer extends DrawerTemplate {
             Joiner.prepareFlatEndpoint(B, C, D, E, halfLineWidth);
             vert1(D);
             vert2(E);
-            drawVerts();
+            drawer.pushVerts();
         } else {
             //draw last link on path
             A.set(path[0], path[1]);
             Joiner.preparePointyJoin(B, C, A, D, E, halfLineWidth);
             vert1(E);
             vert2(D);
-            drawVerts();
+            drawer.pushVerts();
             //draw connection back to first vertex
             vert3(D0);
             vert4(E0);
-            drawVerts();
+            drawer.pushVerts();
         }
     }
 
@@ -156,7 +161,7 @@ class PathDrawer extends DrawerTemplate {
                 vert2(E);
             }
 
-            drawVerts();
+            drawer.pushVerts();
             drawSmoothJoinFill(A, B, C, D, E, halfLineWidth);
 
             Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, true);
@@ -174,7 +179,7 @@ class PathDrawer extends DrawerTemplate {
             Joiner.prepareFlatEndpoint(B, C, D, E, halfLineWidth);
             vert3(D);
             vert4(E);
-            drawVerts();
+            drawer.pushVerts();
         } else {
             //draw last link on path
             A.set(B);
@@ -183,7 +188,7 @@ class PathDrawer extends DrawerTemplate {
             Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, false);
             vert3(E);
             vert4(D);
-            drawVerts();
+            drawer.pushVerts();
             drawSmoothJoinFill(A, B, C, D, E, halfLineWidth);
             //draw connection back to first vertex
             Joiner.prepareSmoothJoin(A, B, C, D, E, halfLineWidth, true);
@@ -191,7 +196,7 @@ class PathDrawer extends DrawerTemplate {
             vert4(D);
             vert1(D0);
             vert2(E0);
-            drawVerts();
+            drawer.pushVerts();
             A.set(path[2], path[3]);
             drawSmoothJoinFill(B, C, A, D0, E0, halfLineWidth);
         }

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonDrawer.java
@@ -20,13 +20,13 @@ class PolygonDrawer extends DrawerTemplate {
         centre.set(centreX, centreY);
         radius.set(radiusX, radiusY);
 
-        drawer.startCaching();
+        boolean wasCaching = drawer.startCaching();
         if (joinType==JoinType.NONE) {
             drawPolygonNoJoin(centre, sides, lineWidth, rotation, radius, startAngle, radians);
         } else {
             drawPolygonWithJoin(centre, sides, halfLineWidth, rotation, radius, startAngle, radians, joinType==JoinType.SMOOTH);
         }
-        drawer.endCaching();
+        if (!wasCaching) drawer.endCaching();
     }
 
     void drawPolygonNoJoin(Vector2 centre, int sides, float lineWidth, float rotation, Vector2 radius, float startAngle, float radians) {

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonDrawer.java
@@ -1,5 +1,4 @@
 package space.earlygrey.shapedrawer;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
 
@@ -21,11 +20,13 @@ class PolygonDrawer extends DrawerTemplate {
         centre.set(centreX, centreY);
         radius.set(radiusX, radiusY);
 
+        drawer.startCaching();
         if (joinType==JoinType.NONE) {
             drawPolygonNoJoin(centre, sides, lineWidth, rotation, radius, startAngle, radians);
         } else {
             drawPolygonWithJoin(centre, sides, halfLineWidth, rotation, radius, startAngle, radians, joinType==JoinType.SMOOTH);
         }
+        drawer.endCaching();
     }
 
     void drawPolygonNoJoin(Vector2 centre, int sides, float lineWidth, float rotation, Vector2 radius, float startAngle, float radians) {
@@ -45,7 +46,7 @@ class PolygonDrawer extends DrawerTemplate {
         for (int i = start; i <= end; i++) {
             float x1 = A.x*cosRot-A.y*sinRot  + centre.x, y1 = A.x*sinRot+A.y*cosRot + centre.y;
             float x2 = B.x*cosRot-B.y*sinRot  + centre.x, y2 = B.x*sinRot+B.y*cosRot + centre.y;
-            drawer.line(x1, y1, x2, y2, lineWidth, false);
+            drawer.lineDrawer.pushLine(x1, y1, x2, y2, lineWidth, false);
             if (i<end-1) {
                 A.set(B);
                 dir.set(dir.x * cos - dir.y * sin, dir.x * sin + dir.y * cos);
@@ -122,7 +123,7 @@ class PolygonDrawer extends DrawerTemplate {
             vert3(D.x*cosRot-D.y*sinRot  + centre.x, D.x*sinRot+D.y*cosRot + centre.y);
             vert4(E.x*cosRot-E.y*sinRot  + centre.x, E.x*sinRot+E.y*cosRot + centre.y);
 
-            drawVerts(); //draw current AB
+            drawer.pushVerts(); //push current AB
 
             if (smooth && (full || i<end)) drawSmoothJoinFill(A, B, C, D, E, centre, cosRot, sinRot, halfLineWidth);
         }


### PR DESCRIPTION
Instead of pushing a float[20] to the Batch every time a quad is calculated, the floats are stored in a larger float[] which is then pushed to the Batch when full or finished.
Currently affects polygon and path drawing, but may be used in the future to return cache objects to the user. I also thought it would improve performance, but I can't detect any difference.