### PR TITLE
Fixes/polygon batch array crash

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -31,10 +31,6 @@ public abstract class AbstractShapeDrawer {
 
     protected static final Matrix4 mat4 = new Matrix4();
 
-    // These are named just for clarity
-    static final int VERTEX_SIZE = 5, QUAD_PUSH_SIZE = 4 * VERTEX_SIZE;
-
-
     protected final LineDrawer lineDrawer;
     protected final PathDrawer pathDrawer;
     protected final PolygonDrawer polygonDrawer;

--- a/drawer/src/space/earlygrey/shapedrawer/BatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/BatchManager.java
@@ -23,8 +23,7 @@ class BatchManager {
     protected final Batch batch;
     protected TextureRegion r;
     protected float floatBits;
-    static final int VERTEX_CACHE_SIZE = 2000;
-    protected final float[] verts;
+    protected float[] verts;
     protected int vertexCount;
 
     protected float pixelSize = 1, halfPixelSize = 0.5f * pixelSize;
@@ -34,11 +33,12 @@ class BatchManager {
     protected static final Matrix4 mat4 = new Matrix4();
 
     // These are named just for clarity
+    static final int DEFAULT_VERTEX_CACHE_SIZE = 2000;
     static final int VERTEX_SIZE = 5, QUAD_PUSH_SIZE = 4 * VERTEX_SIZE;
 
     BatchManager (Batch batch, TextureRegion region) {
         this.batch = batch;
-        verts = new float[VERTEX_CACHE_SIZE];
+        verts = new float[DEFAULT_VERTEX_CACHE_SIZE];
         setTextureRegion(region);
         setColor(Color.WHITE);
     }
@@ -182,7 +182,21 @@ class BatchManager {
         ensureSpace(4);
     }
     void ensureSpace(int vertices) {
-        if (verticesRemaining() < vertices) pushToBatch();
+        if (vertices * VERTEX_SIZE > verts.length) {
+            increaseCacheSize(vertices * VERTEX_SIZE);
+        } else if (verticesRemaining() < vertices) {
+            pushToBatch();
+        }
+
+    }
+
+    void increaseCacheSize(int minSize) {
+        pushToBatch();
+        int newSize = verts.length;
+        while (minSize > newSize) {
+            newSize *= 2;
+        }
+        verts = new float[newSize];
     }
 
     int verticesRemaining() {

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
@@ -11,8 +11,10 @@ class PolygonBatchManager extends BatchManager {
 
     PolygonBatchManager(PolygonBatch batch, TextureRegion region) {
         super(batch, region);
-        // every 4 vertices pushed needs at most 6 triangle indices (6/4 = 1.5)
-        int trianglesLength = (int) Math.ceil((verts.length / VERTEX_SIZE) * 1.5);
+        //need at least (3 * vxs) triangles
+        //n quads arranged in a loop, each sharing 2 vxs with the next requires 2n vertices
+        // and 2n triangles (so 2n*3 indices)
+        int trianglesLength = (int) Math.ceil((verts.length / VERTEX_SIZE) * 3);
         triangles = new short[trianglesLength];
     }
 

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
@@ -89,6 +89,13 @@ class PolygonBatchManager extends BatchManager {
         triangleCount = 0;
     }
 
+    @Override
+    void increaseCacheSize(int minSize) {
+        super.increaseCacheSize(minSize);
+        int trianglesLength = (int) Math.ceil((verts.length / VERTEX_SIZE) * 3);
+        triangles = new short[trianglesLength];
+    }
+
     int getTrianglesArrayOffset() {
         return 3* triangleCount;
     }


### PR DESCRIPTION
This should fix the out of bounds exception encountered when trying to ensure space for vertices that is larger than the vertex float[] array. Now if that happens, the array is resized so that it's big enough.

Also creates a larger triangles short[] array, as this was sometimes not large enough.