### PR TITLE
Fix shape drawer#filled rectangle(rectangle rect)

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
@@ -1143,7 +1143,7 @@ public class ShapeDrawer extends AbstractShapeDrawer {
      * @param rect a {@link Rectangle} object
      */
     public void filledRectangle(Rectangle rect) {
-        rectangle(rect.x, rect.y, rect.width, rect.height);
+        filledRectangle(rect.x, rect.y, rect.width, rect.height);
     }
 
     /**


### PR DESCRIPTION
Typo resulted in ShapeDrawer#filledRectangle(Rectangle rect) creating an outline instead of a filled shape. This change resolves the issue.