### PR TITLE
Fix the call link of rectangle(Rectangle)

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
@@ -1001,7 +1001,7 @@ public class ShapeDrawer extends AbstractShapeDrawer {
     //====================
 
     /**
-     * <p>Calls {@link #rectangle(Rectangle)} with the current default line width.
+     * <p>Calls {@link #rectangle(Rectangle, float)} with the current default line width.
      * See {@link #rectangle(float, float, float, float, float, JoinType)} for more information.</p>
      * @param rect a {@link Rectangle} object
      */


### PR DESCRIPTION
Hi,

I've found that the call link is wrong in the javadoc of rectangle(Rectangle) method, so I've fixed it.

Best regards,
Dgzt
