### PR TITLE
libGDX branding compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ---
 
-A library for [libgdx](https://github.com/libgdx/libgdx), an open-source game development application framework written in java.
+A library for [libGDX](https://github.com/libgdx/libgdx), an open-source game development application framework written in java.
 
-Draws simple shapes like libgdx's [ShapeRenderer](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/graphics/glutils/ShapeRenderer.html) does, but uses a Batch to perform the drawing. This means it can be used in between `Batch#begin()` and `Batch#end()` without needing to flush the Batch.
+Draws simple shapes like libGDX's [ShapeRenderer](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/graphics/glutils/ShapeRenderer.html) does, but uses a Batch to perform the drawing. This means it can be used in between `Batch#begin()` and `Batch#end()` without needing to flush the Batch.
 
 Comes with overloaded methods to draw lines, paths, ellipses, regular polygons and rectangles.
 


### PR DESCRIPTION
http://libgdx.com/brand/

> The name “libGDX” always starts with a lower-case ``l``, even at the beginning of a sentence. ``GDX`` is always written in upper-case letters.

Also, you might want to fix that `About` description too:

![image](https://user-images.githubusercontent.com/38117856/92297939-4851ed80-ef12-11ea-8658-8f4cd49efc36.png)

Cheers! (It's amazing how quickly this wonderful library grew: very good job!)