### PR TITLE
Add vertexCacheSize to constructors

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -46,13 +46,13 @@ public abstract class AbstractShapeDrawer {
      * @param region the texture region used for drawing. Can be changed later.
      */
 
-    AbstractShapeDrawer(Batch batch, TextureRegion region) {
+    AbstractShapeDrawer(Batch batch, TextureRegion region, int vertexCacheSize) {
         if (batch instanceof PolygonBatch) {
-            PolygonBatchManager manager = new PolygonBatchManager((PolygonBatch) batch, region);
+            PolygonBatchManager manager = new PolygonBatchManager((PolygonBatch) batch, region, vertexCacheSize);
             filledPolygonDrawer = new PolygonBatchFilledPolygonDrawer(manager, this);
             batchManager = manager;
         } else {
-            batchManager = new BatchManager(batch, region);
+            batchManager = new BatchManager(batch, region, vertexCacheSize);
             filledPolygonDrawer = new BatchFilledPolygonDrawer(batchManager, this);
         }
 

--- a/drawer/src/space/earlygrey/shapedrawer/BatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/BatchManager.java
@@ -38,9 +38,9 @@ class BatchManager {
     static final int DEFAULT_VERTEX_CACHE_SIZE = 2000;
     static final int VERTEX_SIZE = 5, QUAD_PUSH_SIZE = 4 * VERTEX_SIZE;
 
-    BatchManager (Batch batch, TextureRegion region) {
+    BatchManager(Batch batch, TextureRegion region, int vertexCacheSize) {
         this.batch = batch;
-        verts = new float[DEFAULT_VERTEX_CACHE_SIZE];
+        verts = new float[vertexCacheSize];
         setTextureRegion(region);
         setColor(Color.WHITE);
     }

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
@@ -11,8 +11,8 @@ class PolygonBatchManager extends BatchManager {
     protected short[] triangles;
     protected int triangleCount = 0;
 
-    PolygonBatchManager(PolygonBatch batch, TextureRegion region) {
-        super(batch, region);
+    PolygonBatchManager(PolygonBatch batch, TextureRegion region, int vertexCacheSize) {
+        super(batch, region, vertexCacheSize);
         //need at least (3 * vxs) triangles
         //n quads arranged in a loop, each sharing 2 vxs with the next requires 2n vertices
         // and 2n triangles (so 2n*3 indices)

--- a/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
@@ -37,7 +37,11 @@ public class ShapeDrawer extends AbstractShapeDrawer {
     }
 
     public ShapeDrawer(Batch batch, TextureRegion region) {
-        super(batch, region);
+        this(batch, region, BatchManager.DEFAULT_VERTEX_CACHE_SIZE);
+    }
+    
+    public ShapeDrawer(Batch batch, TextureRegion region, int vertexCacheSize) {
+        super(batch, region, vertexCacheSize);
     }
 
 


### PR DESCRIPTION
When the vertex-cache-limit is hit the first time in my game there is a really noticable lag/long frame.
To avoid this it would be great to be able to set the size of the vertex cache from the beginning.