### PR TITLE
AbstractShapeDrawer.getCacheSize

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -22,7 +22,7 @@ public abstract class AbstractShapeDrawer {
     // MEMBERS
     //================================================================================
 
-    final BatchManager batchManager;
+    protected final BatchManager batchManager;
     float defaultLineWidth = 1;
     boolean defaultSnap = false;
 

--- a/drawer/src/space/earlygrey/shapedrawer/BatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/BatchManager.java
@@ -220,6 +220,10 @@ class BatchManager {
         verts = new float[newSize];
     }
 
+    public final int getCacheSize() {
+        return verts.length;
+    }
+
     int verticesRemaining() {
         return (verts.length - QUAD_PUSH_SIZE * vertexCount) / VERTEX_SIZE;
     }


### PR DESCRIPTION
To avoid lags due to calls to AbstractShapeDrawer.increaseCacheSize I'd like to be able to retrieve the size of the cache so I can increase the start size of the cache (see https://github.com/earlygrey/shapedrawer/pull/38) during development. 