### PR TITLE
ISideEstimator / DefaultSideEstimator

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -35,6 +35,8 @@ public abstract class AbstractShapeDrawer {
     protected final PolygonDrawer polygonDrawer;
     protected final FilledPolygonDrawer filledPolygonDrawer;
 
+    private ISideEstimator sideEstimator;
+
 
     //================================================================================
     // CONSTRUCTOR
@@ -46,7 +48,7 @@ public abstract class AbstractShapeDrawer {
      * @param region the texture region used for drawing. Can be changed later.
      */
 
-    AbstractShapeDrawer(Batch batch, TextureRegion region) {
+    AbstractShapeDrawer(Batch batch, TextureRegion region, ISideEstimator sideEstimator) {
         if (batch instanceof PolygonBatch) {
             PolygonBatchManager manager = new PolygonBatchManager((PolygonBatch) batch, region);
             filledPolygonDrawer = new PolygonBatchFilledPolygonDrawer(manager, this);
@@ -60,6 +62,7 @@ public abstract class AbstractShapeDrawer {
         pathDrawer = new PathDrawer(batchManager, this);
         polygonDrawer = new PolygonDrawer(batchManager, this);
 
+        this.sideEstimator = sideEstimator;
     }
 
     /**
@@ -144,17 +147,20 @@ public abstract class AbstractShapeDrawer {
     }
 
     protected int estimateSidesRequired(float radiusX, float radiusY) {
-        float circumference = (float) (ShapeUtils.PI2 * Math.sqrt((radiusX*radiusX + radiusY*radiusY)/2f));
-        int sides = (int) (circumference / (16 * getPixelSize()));
-        float a = Math.min(radiusX, radiusY), b = Math.max(radiusX, radiusY);
-        float eccentricity = (float) Math.sqrt(1-((a*a) / (b*b)));
-        sides += (sides * eccentricity) / 16;
-        return Math.max(sides, 20);
+        return sideEstimator.estimateSidesRequired(getPixelSize(), radiusX, radiusY);
     }
 
     //================================================================================
     // GETTERS AND SETTERS
     //================================================================================
+
+    /**
+     * <p>Sets a new {@link ISideEstimator}.</p>
+     * @param sideEstimator
+     */
+    public void setSideEstimator(ISideEstimator sideEstimator) {
+        this.sideEstimator = sideEstimator;
+    }
 
     /**
      * <p>This is used internally to make estimates about how things will appear on screen. It affects

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -155,6 +155,14 @@ public abstract class AbstractShapeDrawer {
     //================================================================================
 
     /**
+     *
+     * @return the current {@link ISideEstimator}
+     */
+    public final ISideEstimator getSideEstimator() {
+        return sideEstimator;
+    }
+
+    /**
      * <p>Sets a new {@link ISideEstimator} and returns the old {@link ISideEstimator}.</p>
      * @param sideEstimator
      * @return the old {@link ISideEstimator}

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -35,7 +35,7 @@ public abstract class AbstractShapeDrawer {
     protected final PolygonDrawer polygonDrawer;
     protected final FilledPolygonDrawer filledPolygonDrawer;
 
-    private ISideEstimator sideEstimator;
+    private SideEstimator sideEstimator;
 
 
     //================================================================================
@@ -48,7 +48,7 @@ public abstract class AbstractShapeDrawer {
      * @param region the texture region used for drawing. Can be changed later.
      */
 
-    AbstractShapeDrawer(Batch batch, TextureRegion region, ISideEstimator sideEstimator) {
+    AbstractShapeDrawer(Batch batch, TextureRegion region, SideEstimator sideEstimator) {
         if (batch instanceof PolygonBatch) {
             PolygonBatchManager manager = new PolygonBatchManager((PolygonBatch) batch, region);
             filledPolygonDrawer = new PolygonBatchFilledPolygonDrawer(manager, this);
@@ -156,19 +156,19 @@ public abstract class AbstractShapeDrawer {
 
     /**
      *
-     * @return the current {@link ISideEstimator}
+     * @return the current {@link SideEstimator}
      */
-    public final ISideEstimator getSideEstimator() {
+    public final SideEstimator getSideEstimator() {
         return sideEstimator;
     }
 
     /**
-     * <p>Sets a new {@link ISideEstimator} and returns the old {@link ISideEstimator}.</p>
+     * <p>Sets a new {@link SideEstimator} and returns the old {@link SideEstimator}.</p>
      * @param sideEstimator
-     * @return the old {@link ISideEstimator}
+     * @return the old {@link SideEstimator}
      */
-    public ISideEstimator setSideEstimator(ISideEstimator sideEstimator) {
-        final ISideEstimator oldSideEstimator = this.sideEstimator;
+    public SideEstimator setSideEstimator(SideEstimator sideEstimator) {
+        final SideEstimator oldSideEstimator = this.sideEstimator;
         this.sideEstimator = sideEstimator;
         return oldSideEstimator;
     }

--- a/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/AbstractShapeDrawer.java
@@ -155,11 +155,14 @@ public abstract class AbstractShapeDrawer {
     //================================================================================
 
     /**
-     * <p>Sets a new {@link ISideEstimator}.</p>
+     * <p>Sets a new {@link ISideEstimator} and returns the old {@link ISideEstimator}.</p>
      * @param sideEstimator
+     * @return the old {@link ISideEstimator}
      */
-    public void setSideEstimator(ISideEstimator sideEstimator) {
+    public ISideEstimator setSideEstimator(ISideEstimator sideEstimator) {
+        final ISideEstimator oldSideEstimator = this.sideEstimator;
         this.sideEstimator = sideEstimator;
+        return oldSideEstimator;
     }
 
     /**

--- a/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
@@ -18,7 +18,7 @@ public class DefaultSideEstimator implements ISideEstimator {
 	protected float sideMultiplicator;
 
 	public DefaultSideEstimator() {
-		this(20, 16000, 1f);
+		this(20, 4000, 1f);
 	}
 
 	public DefaultSideEstimator(int minimumSides, int maximumSides, float sideMultiplicator) {

--- a/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
@@ -1,0 +1,13 @@
+package space.earlygrey.shapedrawer;
+
+public class DefaultSideEstimator implements ISideEstimator {
+
+	public int estimateSidesRequired(float pixelSize, float radiusX, float radiusY) {
+		float circumference = (float) (ShapeUtils.PI2 * Math.sqrt((radiusX * radiusX + radiusY * radiusY) / 2f));
+		int sides = (int) (circumference / (16 * pixelSize));
+		float a = Math.min(radiusX, radiusY), b = Math.max(radiusX, radiusY);
+		float eccentricity = (float) Math.sqrt(1 - ((a * a) / (b * b)));
+		sides += (sides * eccentricity) / 16;
+		return Math.max(sides, 20);
+	}
+}

--- a/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
@@ -1,5 +1,7 @@
 package space.earlygrey.shapedrawer;
 
+import com.badlogic.gdx.math.MathUtils;
+
 public class DefaultSideEstimator implements ISideEstimator {
 
 	/**
@@ -31,6 +33,6 @@ public class DefaultSideEstimator implements ISideEstimator {
 		float a = Math.min(radiusX, radiusY), b = Math.max(radiusX, radiusY);
 		float eccentricity = (float) Math.sqrt(1 - ((a * a) / (b * b)));
 		sides += (sides * eccentricity * sideMultiplicator) / 16;
-		return Math.min(Math.max(sides, minimumSides), maximumSides);
+		return MathUtils.clamp(sides, minimumSides, maximumSides);
 	}
 }

--- a/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
@@ -2,12 +2,35 @@ package space.earlygrey.shapedrawer;
 
 public class DefaultSideEstimator implements ISideEstimator {
 
+	/**
+	 * Minimum value returned by {@link #estimateSidesRequired(float, float, float)}
+	 */
+	protected int minimumSides; // 
+	/**
+	 * Maximum value returned by {@link #estimateSidesRequired(float, float, float)}
+	 */
+	protected int maximumSides;
+	/**
+	 * Multiply the number of sides return by this value. {@link #minimumSides} and {@link #maximumSides} are not affected
+	 */
+	protected float sideMultiplicator;
+
+	public DefaultSideEstimator() {
+		this(20, 16000, 1f);
+	}
+
+	public DefaultSideEstimator(int minimumSides, int maximumSides, float sideMultiplicator) {
+		this.minimumSides = minimumSides;
+		this.maximumSides = maximumSides;
+		this.sideMultiplicator = sideMultiplicator;
+	}
+
 	public int estimateSidesRequired(float pixelSize, float radiusX, float radiusY) {
 		float circumference = (float) (ShapeUtils.PI2 * Math.sqrt((radiusX * radiusX + radiusY * radiusY) / 2f));
 		int sides = (int) (circumference / (16 * pixelSize));
 		float a = Math.min(radiusX, radiusY), b = Math.max(radiusX, radiusY);
 		float eccentricity = (float) Math.sqrt(1 - ((a * a) / (b * b)));
-		sides += (sides * eccentricity) / 16;
-		return Math.max(sides, 20);
+		sides += (sides * eccentricity * sideMultiplicator) / 16;
+		return Math.min(Math.max(sides, minimumSides), maximumSides);
 	}
 }

--- a/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
@@ -2,12 +2,16 @@ package space.earlygrey.shapedrawer;
 
 import com.badlogic.gdx.math.MathUtils;
 
-public class DefaultSideEstimator implements ISideEstimator {
+public class DefaultSideEstimator implements SideEstimator {
+
+	//================================================================================
+	// MEMBERS
+	//================================================================================
 
 	/**
 	 * Minimum value returned by {@link #estimateSidesRequired(float, float, float)}
 	 */
-	protected int minimumSides; // 
+	protected int minimumSides;
 	/**
 	 * Maximum value returned by {@link #estimateSidesRequired(float, float, float)}
 	 */
@@ -15,24 +19,32 @@ public class DefaultSideEstimator implements ISideEstimator {
 	/**
 	 * Multiply the number of sides return by this value. {@link #minimumSides} and {@link #maximumSides} are not affected
 	 */
-	protected float sideMultiplicator;
+	protected float sideMultiplier;
+
+	//================================================================================
+	// CONSTRUCTOR
+	//================================================================================
 
 	public DefaultSideEstimator() {
 		this(20, 4000, 1f);
 	}
 
-	public DefaultSideEstimator(int minimumSides, int maximumSides, float sideMultiplicator) {
+	public DefaultSideEstimator(int minimumSides, int maximumSides, float sideMultiplier) {
 		this.minimumSides = minimumSides;
 		this.maximumSides = maximumSides;
-		this.sideMultiplicator = sideMultiplicator;
+		this.sideMultiplier = sideMultiplier;
 	}
+
+	//================================================================================
+	// HELPERS
+	//================================================================================
 
 	public int estimateSidesRequired(float pixelSize, float radiusX, float radiusY) {
 		float circumference = (float) (ShapeUtils.PI2 * Math.sqrt((radiusX * radiusX + radiusY * radiusY) / 2f));
 		int sides = (int) (circumference / (16 * pixelSize));
 		float a = Math.min(radiusX, radiusY), b = Math.max(radiusX, radiusY);
 		float eccentricity = (float) Math.sqrt(1 - ((a * a) / (b * b)));
-		sides += (sides * eccentricity * sideMultiplicator) / 16;
+		sides += (sides * eccentricity * sideMultiplier) / 16;
 		return MathUtils.clamp(sides, minimumSides, maximumSides);
 	}
 
@@ -56,11 +68,11 @@ public class DefaultSideEstimator implements ISideEstimator {
 		this.maximumSides = maximumSides;
 	}
 
-	public float getSideMultiplicator() {
-		return sideMultiplicator;
+	public float getSideMultiplier() {
+		return sideMultiplier;
 	}
 
-	public void setSideMultiplicator(float sideMultiplicator) {
-		this.sideMultiplicator = sideMultiplicator;
+	public void setSideMultiplier(float sideMultiplier) {
+		this.sideMultiplier = sideMultiplier;
 	}
 }

--- a/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/DefaultSideEstimator.java
@@ -35,4 +35,32 @@ public class DefaultSideEstimator implements ISideEstimator {
 		sides += (sides * eccentricity * sideMultiplicator) / 16;
 		return MathUtils.clamp(sides, minimumSides, maximumSides);
 	}
+
+	//================================================================================
+	// GETTERS AND SETTERS
+	//================================================================================
+
+	public int getMinimumSides() {
+		return minimumSides;
+	}
+
+	public void setMinimumSides(int minimumSides) {
+		this.minimumSides = minimumSides;
+	}
+
+	public int getMaximumSides() {
+		return maximumSides;
+	}
+
+	public void setMaximumSides(int maximumSides) {
+		this.maximumSides = maximumSides;
+	}
+
+	public float getSideMultiplicator() {
+		return sideMultiplicator;
+	}
+
+	public void setSideMultiplicator(float sideMultiplicator) {
+		this.sideMultiplicator = sideMultiplicator;
+	}
 }

--- a/drawer/src/space/earlygrey/shapedrawer/ISideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ISideEstimator.java
@@ -1,0 +1,6 @@
+package space.earlygrey.shapedrawer;
+
+public interface ISideEstimator {
+
+	int estimateSidesRequired(float pixelSize, float radiusX, float radiusY);
+}

--- a/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
@@ -34,11 +34,15 @@ public class ShapeDrawer extends AbstractShapeDrawer {
     //================================================================================
 
     public ShapeDrawer(Batch batch) {
-        this(batch, null);
+        this(batch, null, new DefaultSideEstimator());
     }
 
     public ShapeDrawer(Batch batch, TextureRegion region) {
-        super(batch, region);
+        super(batch, region, new DefaultSideEstimator());
+    }
+    
+    public ShapeDrawer(Batch batch, TextureRegion region, ISideEstimator sideEstimator) {
+        super(batch, region, sideEstimator);
     }
 
 

--- a/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
@@ -41,7 +41,7 @@ public class ShapeDrawer extends AbstractShapeDrawer {
         super(batch, region, new DefaultSideEstimator());
     }
     
-    public ShapeDrawer(Batch batch, TextureRegion region, ISideEstimator sideEstimator) {
+    public ShapeDrawer(Batch batch, TextureRegion region, SideEstimator sideEstimator) {
         super(batch, region, sideEstimator);
     }
 

--- a/drawer/src/space/earlygrey/shapedrawer/SideEstimator.java
+++ b/drawer/src/space/earlygrey/shapedrawer/SideEstimator.java
@@ -1,6 +1,6 @@
 package space.earlygrey.shapedrawer;
 
-public interface ISideEstimator {
+public interface SideEstimator {
 
 	int estimateSidesRequired(float pixelSize, float radiusX, float radiusY);
 }


### PR DESCRIPTION
This is my suggestion for the issue addressed by @payne911 in https://github.com/earlygrey/shapedrawer/issues/11 + https://github.com/earlygrey/shapedrawer/pull/46

Regarding `AbstractShapeDrawer#estimateSidesRequired()` there are different needs for different projects.
- Some projects might use this library to draw a lot of small circles. They might need to reduce the number of sides for drawn elements
- Some projects for sure are for mobile and also support low or medium hardware. There performance is any issue. They might need to reduce the number of sides for drawn elements
- Some projects might want to intentionally go for a non-smooth look
- Some projects might go for a really super-smooth look
- Some projects might want to have a setting in the preferences to adjust the level-of-detail of the drawn elements
- Some projects might want to draw elements super smooth while staying low-poly on others
- There are more possibilities for sure...

I guess what we all can agree on is that there needs to be a way to specify estimateSidesRequired(radiusX, radiusY) more precise or to offer ways to access different presets out of the box for different needs. 

My suggestion is to have an `ISideEstimator` interface and have the possibility to easily change this in `AbstractShapeDrawer`.
By default the `DefaultSideEstimator` is set. This can be easily replaced (even between render calls) or injected in the constructor. There's a lot of people who will not deep-dive into a library to adjust it to their needs. And having this might make everything easier to understand.

If somebody has a good proposal for other `ISideEstimator`s they can also just directly be included here in this project without affecting any existing implementations.

(If this would get merged it should be a squash-merge, sorry for the amount of commits)