### PR TITLE
add polygon with offset methods, add drawing polygons as wireframe

### DIFF
--- a/drawer/src/space/earlygrey/shapedrawer/FilledPolygonDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/FilledPolygonDrawer.java
@@ -22,6 +22,8 @@ abstract class FilledPolygonDrawer<T extends BatchManager> extends DrawerTemplat
     abstract void polygon(float centreX, float centreY, int sides, float radiusX, float radiusY, float rotation, float startAngle, float radians, float innerColor, float outerColor);
 
     abstract void polygon(float[] vertices, short[] triangles, int trianglesCount);
+    
+    abstract void polygon(float[] vertices, short[] triangles, int trianglesCount, float offsetX, float offsetY);
 
     void polygon(float[] vertices) {
         polygon(vertices, 0, vertices.length);
@@ -38,6 +40,10 @@ abstract class FilledPolygonDrawer<T extends BatchManager> extends DrawerTemplat
 
     void polygon(float[] vertices, short[] triangles) {
         polygon(vertices, triangles, triangles.length);
+    }
+    
+    void polygon(float[] vertices, short[] triangles, float offsetX, float offsetY) {
+        polygon(vertices, triangles, triangles.length, offsetX, offsetY);
     }
 
     void rectangle(float x, float y, float width, float height, float rotation) {
@@ -175,6 +181,20 @@ abstract class FilledPolygonDrawer<T extends BatchManager> extends DrawerTemplat
             }
             batchManager.pushToBatch();
         }
+        
+        @Override
+        void polygon(float[] vertices, short[] triangles, int trianglesCount, float x, float y) {
+            float c = batchManager.floatBits;
+            for (int i = 0; i < trianglesCount; i += 3) {
+                batchManager.ensureSpaceForTriangle();
+                vert1(vertices[2 * triangles[i]] + x, vertices[2 * triangles[i] + 1] + y);
+                vert2(vertices[2 * triangles[i + 1]] + x, vertices[2 * triangles[i + 1] + 1] + y);
+                vert3(vertices[2 * triangles[i + 2]] + x, vertices[2 * triangles[i + 2] + 1] + y);
+                color(c, c, c);
+                batchManager.pushTriangle();
+            }
+            batchManager.pushToBatch();
+        }
     }
 
     static class PolygonBatchFilledPolygonDrawer extends FilledPolygonDrawer<PolygonBatchManager> {
@@ -247,6 +267,15 @@ abstract class FilledPolygonDrawer<T extends BatchManager> extends DrawerTemplat
             int n = vertices.length / 2;
             batchManager.ensureSpace(n);
             batchManager.pushVertexData(vertices, triangles, trianglesCount, batchManager.floatBits);
+            batchManager.pushToBatch();
+        }
+
+        @Override
+        void polygon(float[] vertices, short[] triangles, int trianglesCount, float offsetX, float offsetY) {
+            int n = vertices.length / 2;
+            batchManager.ensureSpace(n);
+            batchManager.pushVertexData(vertices, triangles, trianglesCount, batchManager.floatBits,
+                    offsetX, offsetY);
             batchManager.pushToBatch();
         }
 

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonBatchManager.java
@@ -54,7 +54,12 @@ class PolygonBatchManager extends BatchManager {
         triangleCount++;
     }
 
-    protected void pushVertexData(float[] vertices, short[] triangles, int trianglesArrayCount, float color)  {
+    protected void pushVertexData(float[] vertices, short[] triangles, int trianglesArrayCount, float color) {
+        pushVertexData(vertices, triangles, trianglesArrayCount, color, 0f, 0f);
+    }
+
+    protected void pushVertexData(float[] vertices, short[] triangles, int trianglesArrayCount,
+                                  float color, float offsetX, float offsetY) {
 
         int v = getVerticesArrayIndex();
 
@@ -65,7 +70,7 @@ class PolygonBatchManager extends BatchManager {
         triangleCount += trianglesArrayCount / 3;
 
         for (int j = 0; j < vertices.length; j+=2) {
-            float x = vertices[j], y = vertices[j+1];
+            float x = vertices[j] + offsetX, y = vertices[j + 1] + offsetY;
             verts[v + SpriteBatch.X1] = x;
             verts[v + SpriteBatch.Y1] = y;
             verts[v + SpriteBatch.C1] = color;

--- a/drawer/src/space/earlygrey/shapedrawer/PolygonDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/PolygonDrawer.java
@@ -27,6 +27,22 @@ class PolygonDrawer extends DrawerTemplate<BatchManager> {
         }
         if (!wasCaching) batchManager.endCaching();
     }
+    
+    void polygonWireframe(float[] vertices, short[] triangles, float offsetX, float offsetY) {
+        if (triangles.length == 0) return;
+        float[] v = vertices;
+        short[] t = triangles;
+        boolean wasCaching = batchManager.startCaching();
+        for (int i = 0; i < t.length; i += 3) {
+            drawer.lineDrawer.pushLine(offsetX + v[2 * t[i]], offsetY + v[2 * t[i] + 1],
+                    offsetX + v[2 * t[i + 1]], offsetY + v[2 * t[i + 1] + 1], 1f, false);
+            drawer.lineDrawer.pushLine(offsetX + v[2 * t[i + 1]], offsetY + v[2 * t[i + 1] + 1],
+                    offsetX + v[2 * t[i + 2]], offsetY + v[2 * t[i + 2] + 1], 1f, false);
+            drawer.lineDrawer.pushLine(offsetX + v[2 * t[i]], offsetY + v[2 * t[i] + 1],
+                    offsetX + v[2 * t[i + 2]], offsetY + v[2 * t[i + 2] + 1], 1f, false);
+        }
+        if (!wasCaching) batchManager.endCaching();
+    }
 
     void drawPolygonNoJoin(Vector2 centre, int sides, float lineWidth, float rotation, Vector2 radius, float startAngle, float radians) {
         float angleInterval = MathUtils.PI2 / sides;

--- a/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
+++ b/drawer/src/space/earlygrey/shapedrawer/ShapeDrawer.java
@@ -947,6 +947,13 @@ public class ShapeDrawer extends AbstractShapeDrawer {
     public void polygon(float[] vertices, int start, int end, float lineWidth, JoinType joinType) {
         pathDrawer.path(vertices, start, end, lineWidth, joinType, false);
     }
+    
+    /**
+     * <p>Draws the wireframe model of the given polygon triangles</p>
+     */
+    public void polygonWireframe(float[] vertices, short[] triangles, float offsetX, float offsetY) {
+        polygonDrawer.polygonWireframe(vertices, triangles, offsetX, offsetY);
+    }
 
     //====================
     //     FILLED
@@ -1030,6 +1037,10 @@ public class ShapeDrawer extends AbstractShapeDrawer {
      */
     public void filledPolygon(float[] vertices, ShortArray triangles) {
         filledPolygonDrawer.polygon(vertices, triangles);
+    }
+    
+    public void filledPolygon(float[] vertices, short[] triangles, float offsetX, float offsetY) {
+        filledPolygonDrawer.polygon(vertices, triangles, offsetX, offsetY);
     }
 
 


### PR DESCRIPTION
- add `polygon` methods with offset (x/y). This allows to reuse existing vertices arrays instead of recalculating them for every draw call.
- add `polygonWireframe` method to draw the outline of a polygon useful for debugging manually created polygons.